### PR TITLE
Fixed typo

### DIFF
--- a/_data/direct_chambery.yml
+++ b/_data/direct_chambery.yml
@@ -6,7 +6,7 @@
 
 - time: "20:22"
   content: |
-    Des hauts-parleur dans la rue, les passant.e.s reconnaissent la voix
+    Des haut-parleurs dans la rue, les passant.e.s reconnaissent la voix
     de Mélenchon et passent voir cette salle pleine à craquer. Les curieux
     affluent, les derniers arrivés peuvent même s'installer sur les terrasses
     en face pour écouter tout en étant assis.


### PR DESCRIPTION
https://fr.wiktionary.org/wiki/haut-parleurs